### PR TITLE
Fix: pull_request_target checkout refs

### DIFF
--- a/.github/workflows/pull_request_target_if_job.yml
+++ b/.github/workflows/pull_request_target_if_job.yml
@@ -8,31 +8,31 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   job2:
     if: github.event.label.name == 'ok'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   job3:
     if: github.actor == 'ok'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   job4:
     if: github.actor == 'ok' || true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   job5:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull_request_target_if_step.yml
+++ b/.github/workflows/pull_request_target_if_step.yml
@@ -9,23 +9,23 @@ jobs:
     - uses: actions/checkout@v2
       if: contains(github.event.issue.labels.*.name, 'ok')
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/checkout@v2
       if: github.event.label.name == 'ok'
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/checkout@v2
       if: github.actor == 'ok'
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/checkout@v2
       if: github.actor == 'ok' || true
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull_request_target_label_only.yml
+++ b/.github/workflows/pull_request_target_label_only.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull_request_target_labels_sequence.yml
+++ b/.github/workflows/pull_request_target_labels_sequence.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull_request_target_mapping.yml
+++ b/.github/workflows/pull_request_target_mapping.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull_request_target_run.yml
+++ b/.github/workflows/pull_request_target_run.yml
@@ -6,6 +6,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - run: make

--- a/.github/workflows/pull_request_target_sequence.yml
+++ b/.github/workflows/pull_request_target_sequence.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Switch from `ref` to `sha`, as `ref` also requires `repository` to be set for fork PRs